### PR TITLE
Fix deprecated Buffer class

### DIFF
--- a/lib/packet.js
+++ b/lib/packet.js
@@ -55,7 +55,7 @@ var fromBuffer = function(b) {
 
 var toBuffer = function() {
   var buffer, hex, i, key, octet, opt, padded, pos, value, _i, _j, _k, _l, _len, _len1, _len2, _len3, _ref, _ref1, _ref2, _ref3;
-  buffer = new Buffer(512, 'ascii');
+  buffer = new Buffer.alloc(512, 0x00, 'ascii');
   buffer[0] = this.op;
   buffer[1] = this.htype;
   buffer.writeUInt8(this.hlen, 2);
@@ -98,7 +98,7 @@ var toBuffer = function() {
     }
   }
   buffer[pos] = 255;
-  padded = new Buffer(pos, 'ascii');
+  padded = new Buffer.alloc(pos, 0x00, 'ascii');
   buffer.copy(padded, 0, 0, pos);
   return padded;
 };


### PR DESCRIPTION
The Buffer syntax used before this commit has been deprecated and
doesn't work anymore. This commit use the new syntax to allocate a
Buffer.